### PR TITLE
[Fix] 에디터 끝 도달 시 마우스 이탈 없이 페이지 스크롤이 가능하도록 개선

### DIFF
--- a/web/src/components/problems/code-editor.tsx
+++ b/web/src/components/problems/code-editor.tsx
@@ -33,11 +33,13 @@ export function CodeEditor({
 		if (!editorRef.current) return;
 
 		const now = Date.now();
+		// Reset accumulator if scrolling paused
 		if (now - lastScrollTime.current > 300) {
 			scrollAccumulator.current = 0;
 		}
 		lastScrollTime.current = now;
 
+		// Threshold before passing scroll to browser
 		const LIMIT = 140;
 		const editor = editorRef.current;
 		const scrollTop = editor.getScrollTop();
@@ -52,22 +54,29 @@ export function CodeEditor({
 		let shouldPassToBrowser = isEditorEmpty;
 
 		if (!isEditorEmpty) {
+			// Calculate threshold if scrolling up at the top
 			if (isAtTop && e.deltaY < 0) {
 				scrollAccumulator.current += Math.abs(e.deltaY);
 				if (scrollAccumulator.current > LIMIT) {
 					shouldPassToBrowser = true;
 				}
-			} else if (isAtBottom && e.deltaY > 0) {
+			}
+			// Calculate threshold if scrolling down at the bottom
+			else if (isAtBottom && e.deltaY > 0) {
 				scrollAccumulator.current += Math.abs(e.deltaY);
 				if (scrollAccumulator.current > LIMIT) {
 					shouldPassToBrowser = true;
 				}
-			} else {
+			}
+			// Reset if scrolling normally inside editor
+			else {
 				scrollAccumulator.current = 0;
 			}
 		}
 
 		if (shouldPassToBrowser) {
+			// Stop propagation in capture phase so Monaco editor won't block it via preventDefault
+			// This allows the browser to natively scroll the window/container
 			e.stopPropagation();
 		}
 	};

--- a/web/src/components/problems/code-editor.tsx
+++ b/web/src/components/problems/code-editor.tsx
@@ -2,6 +2,7 @@
 
 import Editor from "@monaco-editor/react";
 import { useTheme } from "next-themes";
+import { useRef } from "react";
 import type { Language } from "@/db/schema";
 
 interface CodeEditorProps {
@@ -20,13 +21,64 @@ export function CodeEditor({
 	height = "400px",
 }: CodeEditorProps) {
 	const { resolvedTheme } = useTheme();
+	const editorRef = useRef<any>(null);
+	const scrollAccumulator = useRef(0);
+	const lastScrollTime = useRef(0);
+
+	const handleEditorDidMount = (editor: any) => {
+		editorRef.current = editor;
+	};
+
+	const handleWheelCapture = (e: React.WheelEvent<HTMLDivElement>) => {
+		if (!editorRef.current) return;
+
+		const now = Date.now();
+		if (now - lastScrollTime.current > 300) {
+			scrollAccumulator.current = 0;
+		}
+		lastScrollTime.current = now;
+
+		const LIMIT = 140;
+		const editor = editorRef.current;
+		const scrollTop = editor.getScrollTop();
+		const scrollHeight = editor.getScrollHeight();
+		const layoutInfo = editor.getLayoutInfo();
+		const clientHeight = layoutInfo ? layoutInfo.height : 0;
+
+		const isAtTop = scrollTop === 0;
+		const isAtBottom = Math.ceil(scrollTop + clientHeight) >= scrollHeight;
+		const isEditorEmpty = !code || code.trim() === "";
+
+		let shouldPassToBrowser = isEditorEmpty;
+
+		if (!isEditorEmpty) {
+			if (isAtTop && e.deltaY < 0) {
+				scrollAccumulator.current += Math.abs(e.deltaY);
+				if (scrollAccumulator.current > LIMIT) {
+					shouldPassToBrowser = true;
+				}
+			} else if (isAtBottom && e.deltaY > 0) {
+				scrollAccumulator.current += Math.abs(e.deltaY);
+				if (scrollAccumulator.current > LIMIT) {
+					shouldPassToBrowser = true;
+				}
+			} else {
+				scrollAccumulator.current = 0;
+			}
+		}
+
+		if (shouldPassToBrowser) {
+			e.stopPropagation();
+		}
+	};
 
 	return (
-		<div className="border rounded-md overflow-hidden">
+		<div className="border rounded-md overflow-hidden" onWheelCapture={handleWheelCapture}>
 			<Editor
 				height={height}
 				language={language === "text" ? "plaintext" : language}
 				value={code}
+				onMount={handleEditorDidMount}
 				onChange={(value) => {
 					if (!readOnly && onChange) {
 						onChange(value || "");


### PR DESCRIPTION
코드 에디터 내부에서 스크롤 시, 에디터 끝(최상단/최하단)에 도달하더라도 스크롤 이벤트가 에디터 안에 갇혀 부모 페이지로 전달되지 않는 불편함을 개선했습니다. 사용자가 에디터 경계에서 일정 수준 이상의 스크롤 힘(가속도)을 가할 경우, 이를 '페이지 이동 의도'로 간주하고 브라우저에 스크롤 권한을 넘겨주도록 로직을 수정했습니다.

스크롤 누적 시스템(Scroll Accumulator) 도입: useRef를 사용하여 에디터 끝에 도달한 상태에서 발생하는 스크롤 델타(Delta) 값을 누적합니다.

임계값(LIMIT) 설정: 누적된 스크롤 값이 140을 초과할 경우에만 이벤트 전파를 허용하여, 실수로 페이지가 튕기는 현상을 방지합니다.

시간 기반 리셋 로직: 마지막 스크롤 발생 후 300ms가 지나면 누적된 값이 초기화되도록 하여 연속적이고 의도적인 스크롤에만 반응하도록 설계했습니다.

Capture Phase 활용: handleWheelCapture를 통해 이벤트 캡처 단계에서 stopPropagation()을 제어함으로써, 에디터 자체의 기본 동작과 브라우저의 기본 스크롤 동작을 유연하게 연결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code editor scroll handling to allow page scrolling when the editor reaches scroll boundaries or is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->