### PR TITLE
fix(header): 우상단 아바타 프로필 이미지 및 닉네임 이니셜 적용

### DIFF
--- a/web/src/app/profile/[userName]/profile-header.tsx
+++ b/web/src/app/profile/[userName]/profile-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Pencil, Save, X } from "lucide-react";
+import { useSession } from "next-auth/react";
 import { useState, useTransition } from "react";
 import { updateProfile } from "@/actions/profile";
 import { TierBadge } from "@/components/tier/tier-badge";
@@ -31,6 +32,7 @@ export function ProfileHeader({
 	stats: UserStats;
 	isOwner: boolean;
 }) {
+	const { update: updateSession } = useSession();
 	const [editing, setEditing] = useState(false);
 	const [name, setName] = useState(user.name);
 	const [bio, setBio] = useState(user.bio ?? "");
@@ -41,11 +43,16 @@ export function ProfileHeader({
 
 	const handleSave = () => {
 		startTransition(async () => {
+			const trimmedName = name.trim();
+			const nextAvatarUrl = avatarUrl.trim() || null;
 			await updateProfile({
-				name: name.trim(),
+				name: trimmedName,
 				bio: bio.trim() || null,
-				avatarUrl: avatarUrl.trim() || null,
+				avatarUrl: nextAvatarUrl,
 			});
+			if (isOwner) {
+				await updateSession({ name: trimmedName, avatarUrl: nextAvatarUrl });
+			}
 			setEditing(false);
 		});
 	};

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -54,12 +54,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 				return {
 					id: user[0].id.toString(),
 					email: user[0].email ?? undefined,
-					name: user[0].username,
+					name: user[0].name,
 					username: user[0].username,
 					role: user[0].role,
 					contestAccountOnly: user[0].contestAccountOnly ?? undefined,
 					contestId: user[0].contestId ?? undefined,
 					mustChangePassword: user[0].mustChangePassword ?? false,
+					avatarUrl: user[0].avatarUrl ?? null,
 				};
 			},
 		}),
@@ -151,26 +152,40 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 					if (dbUser.length > 0) {
 						token.id = dbUser[0].id.toString();
 						token.username = dbUser[0].username;
+						token.name = dbUser[0].name;
 						token.role = dbUser[0].role;
 						token.contestAccountOnly = dbUser[0].contestAccountOnly;
 						token.contestId = dbUser[0].contestId;
 						token.mustChangePassword = false; // OAuth 계정은 비밀번호 없음
+						token.avatarUrl = dbUser[0].avatarUrl ?? null;
 					}
 				} else {
 					// Credentials 로그인
 					token.id = user.id;
 					token.username = user.username;
+					token.name = user.name;
 					token.role = user.role;
 					token.contestAccountOnly = user.contestAccountOnly;
 					token.contestId = user.contestId;
 					token.mustChangePassword = user.mustChangePassword ?? false;
+					token.avatarUrl = user.avatarUrl ?? null;
 				}
 			}
 			// 클라이언트에서 update() 호출 시 세션 페이로드 반영
 			if (trigger === "update" && session && typeof session === "object") {
-				const next = session as { mustChangePassword?: boolean };
+				const next = session as {
+					mustChangePassword?: boolean;
+					name?: string | null;
+					avatarUrl?: string | null;
+				};
 				if (typeof next.mustChangePassword === "boolean") {
 					token.mustChangePassword = next.mustChangePassword;
+				}
+				if (typeof next.name === "string") {
+					token.name = next.name;
+				}
+				if (next.avatarUrl === null || typeof next.avatarUrl === "string") {
+					token.avatarUrl = next.avatarUrl;
 				}
 			}
 			return token;
@@ -179,10 +194,12 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 			if (session.user) {
 				session.user.id = token.id as string;
 				session.user.username = token.username as string;
+				session.user.name = (token.name as string | null | undefined) ?? session.user.name;
 				session.user.role = token.role as string;
 				session.user.contestAccountOnly = token.contestAccountOnly as boolean;
 				session.user.contestId = token.contestId as number | null;
 				session.user.mustChangePassword = (token.mustChangePassword as boolean) ?? false;
+				session.user.avatarUrl = (token.avatarUrl as string | null | undefined) ?? null;
 
 				// 대리 로그인 처리
 				if (token.role === "admin") {
@@ -207,6 +224,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 							session.user.contestAccountOnly = targetUser.contestAccountOnly ?? false;
 							session.user.contestId = targetUser.contestId ?? null;
 							session.user.mustChangePassword = targetUser.mustChangePassword ?? false;
+							session.user.avatarUrl = targetUser.avatarUrl ?? null;
 						}
 					}
 				}

--- a/web/src/components/auth/user-menu.tsx
+++ b/web/src/components/auth/user-menu.tsx
@@ -3,7 +3,7 @@
 import { LogOut, Settings, Shield, User } from "lucide-react";
 import Link from "next/link";
 import { signOut, useSession } from "next-auth/react";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -43,6 +43,7 @@ export function UserMenu() {
 			.toUpperCase()
 			.slice(0, 2) || "U";
 
+	const avatarSrc = currentUser.avatarUrl ?? currentUser.image ?? undefined;
 	const isAdmin = currentUser.role === "admin";
 
 	return (
@@ -53,6 +54,7 @@ export function UserMenu() {
 					className="relative h-9 w-9 rounded-full hover:bg-header-foreground/10"
 				>
 					<Avatar className="h-9 w-9">
+						<AvatarImage src={avatarSrc} alt={currentUser.name ?? currentUser.username} />
 						<AvatarFallback className="bg-primary text-primary-foreground">
 							{initials}
 						</AvatarFallback>

--- a/web/src/types/next-auth.d.ts
+++ b/web/src/types/next-auth.d.ts
@@ -9,6 +9,7 @@ declare module "next-auth" {
 			contestAccountOnly: boolean;
 			contestId: number | null;
 			mustChangePassword: boolean;
+			avatarUrl: string | null;
 			impersonator?: { id: string; username: string };
 		} & DefaultSession["user"];
 	}
@@ -19,6 +20,7 @@ declare module "next-auth" {
 		contestAccountOnly?: boolean;
 		contestId?: number | null;
 		mustChangePassword?: boolean;
+		avatarUrl?: string | null;
 	}
 }
 
@@ -30,5 +32,6 @@ declare module "next-auth/jwt" {
 		contestAccountOnly?: boolean;
 		contestId?: number | null;
 		mustChangePassword?: boolean;
+		avatarUrl?: string | null;
 	}
 }


### PR DESCRIPTION
Closes #13 

## 변경 사항

  ### `fix(auth)` 세션 페이로드 정정
  - Credentials 로그인 시 `session.user.name`이 `username`으로 덮어써지던 문제 수정
  - jwt/session 콜백에서 `avatarUrl`을 토큰·세션으로 전달 (credentials + google)
  - `update` trigger로 `name`/`avatarUrl` 변경이 즉시 반영되도록 확장
  - `next-auth.d.ts`에 `avatarUrl` 타입 추가

  ### `fix(header)` UI 렌더링 + 즉시 반영
  - `UserMenu`에 `<AvatarImage>` 추가 — `avatarUrl` 있으면 이미지, 없으면 이니셜 fallback
  - 이니셜은 기존대로 `name`(닉네임) 기반
  - `ProfileHeader`에서 저장 후 `useSession().update()` 호출로 재로그인 없이 헤더 즉시 갱신

  ## 스크린샷
`fallback이 username(아이디)이 아닌 name(닉네임)의 이니셜로 작동`
<img width="1241" height="452" alt="스크린샷 2026-04-21 오후 9 46 02" src="https://github.com/user-attachments/assets/53e9af12-25ac-41b9-9729-d575c73ab7c8" />

`프로필 이미지가 있는 경우 프로필뿐 아니라 우상단에 프로필 이미지 표시`
<img width="1263" height="456" alt="스크린샷 2026-04-21 오후 9 46 17" src="https://github.com/user-attachments/assets/e9871391-4c11-4569-afad-727b8395f138" />


  ## 테스트
  - [x] Credentials 회원가입 → 우상단 이니셜이 닉네임 첫 글자
  - [x] 프로필에서 avatarUrl 설정 → 저장 즉시 우상단 아바타 반영 (로그아웃 불필요)
  - [x] avatarUrl 비우고 저장 → fallback 이니셜로 복귀
  - [x] Google OAuth (로컬 환경 세팅 안 돼서 미검증)
  - [x] 관리자 대리 로그인(impersonation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now upload and manage their profile avatar/picture
  * Profile avatars persist across sessions and display throughout the application, including the user menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->